### PR TITLE
Collect message before completing epoch

### DIFF
--- a/ff/ff_epoch.c
+++ b/ff/ff_epoch.c
@@ -128,6 +128,22 @@ bool epochCollect(EPOCH_t *coll, PARSER_MSG_t *msg, EPOCH_t *epoch)
             break;
     }
 
+    // Collect data
+    switch (msg->type)
+    {
+        case PARSER_MSGTYPE_UBX:
+            _collectUbx(coll, collect, msg);
+            break;
+        case PARSER_MSGTYPE_NMEA:
+            if (haveNmea)
+            {
+                _collectNmea(coll, collect, &nmea);
+            }
+            break;
+        default:
+            break;
+    }
+
     // Output epoch
     if (complete)
     {
@@ -145,22 +161,6 @@ bool epochCollect(EPOCH_t *coll, PARSER_MSG_t *msg, EPOCH_t *epoch)
         *detect = saveDetect;
 
         //DEBUG("epoch %u ubx %u %d nmea %d %d", seq, tow, detectHaveTow, ms, detectHaveMs);
-    }
-
-    // Collect data
-    switch (msg->type)
-    {
-        case PARSER_MSGTYPE_UBX:
-            _collectUbx(coll, collect, msg);
-            break;
-        case PARSER_MSGTYPE_NMEA:
-            if (haveNmea)
-            {
-                _collectNmea(coll, collect, &nmea);
-            }
-            break;
-        default:
-            break;
     }
 
     return complete;


### PR DESCRIPTION
Hello Flipflip

I created a PR to discuss this issue I have using ubloxcfg.

I use the library in a thread to get GNSS data from a ublox F9P. My thread uses ubloxcfg to parse incoming message using **epochCollect** function.
After calling this function I read the **epoch** structure to get GNSS time, but when calling this function **epoch** is not updated to current time (It still has time of the last batch of messages, meaning that I am one second late).

Do you think I should be using **coll** structure instead or should my change be validated for **epoch** to correspond to **coll** structure ?

Thank you again for your amazing work on ubloxcfg, we love it. I will update my code to be able to use your upstream version

Best regards,
Charles