### PR TITLE
change flock UNLOCK call

### DIFF
--- a/ff/ff_port.c
+++ b/ff/ff_port.c
@@ -526,8 +526,8 @@ static bool _portOpenSer(PORT_t *port)
     if (tcsetattr(fileno, TCSANOW, &settings) != 0)
     {
         PORT_WARNING("Failed configuring device: %s", _portErrStr(port, 0));
-        close(fileno);
         flock(fileno, LOCK_UN);
+        close(fileno);
         return false;
     }
 
@@ -559,8 +559,8 @@ static void _portCloseSer(PORT_t *port)
 #ifdef _WIN32
     CloseHandle((HANDLE)port->handle);
 #else
-    close(port->fd);
     flock(port->fd, LOCK_UN);
+    close(port->fd);
 #endif
 }
 


### PR DESCRIPTION
flock() was called after file descriptor was closed. This is bad
style, because such call always returns error. Fix it by changing
sequence of calls. Another solution is to simply remove this call
because file lock is released when file descriptor is closed.