### PR TITLE
Add UBX-TIM-SVIN

### DIFF
--- a/ff/ff_ubx.h
+++ b/ff/ff_ubx.h
@@ -183,6 +183,7 @@ extern "C" {
 #define UBX_SEC_UNIQUEID_MSGID       0x03
 
 #define UBX_TIM_CLSID                0x0d
+#define UBX_TIM_SVIN_MSGID           0x04
 #define UBX_TIM_TM2_MSGID            0x03
 #define UBX_TIM_TP_MSGID             0x01
 #define UBX_TIM_VRFY_MSGID           0x06
@@ -330,6 +331,7 @@ extern "C" {
     _P_(UBX_RXM_CLSID, UBX_RXM_QZSSL6_MSGID,      "UBX-RXM-QZSSL6") \
     _P_(UBX_RXM_CLSID, UBX_RXM_SPARTNKEY_MSGID,   "UBX-RXM-SPARTNKEY") \
     _P_(UBX_SEC_CLSID, UBX_SEC_UNIQUEID_MSGID,    "UBX-SEC-UNIQUEID") \
+    _P_(UBX_TIM_CLSID, UBX_TIM_SVIN_MSGID,        "UBX-TIM-SVIN") \
     _P_(UBX_TIM_CLSID, UBX_TIM_TM2_MSGID,         "UBX-TIM-TM2") \
     _P_(UBX_TIM_CLSID, UBX_TIM_TP_MSGID,          "UBX-TIM-TP") \
     _P_(UBX_TIM_CLSID, UBX_TIM_VRFY_MSGID,        "UBX-TIM-VRFY") \
@@ -1676,6 +1678,24 @@ typedef struct UBX_TIME_TP_V0_GROUP0_s
 #define UBX_TIM_TP_V0_UTCSTANDARD_SU                                 6
 #define UBX_TIM_TP_V0_UTCSTANDARD_NTSC                               7
 #define UBX_TIM_TP_V0_UTCSTANDARD_UNNOWN                             15
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+//! UBX-TIM_SVIN payload
+typedef struct UBX_TIME_SVIN_V0_GROUP0_s
+{
+    uint32_t dur;
+    int32_t  meanX;
+    int32_t  meanY;
+    int32_t  meanZ;
+    uint32_t meanV;
+    uint32_t obs;
+    uint8_t  valid;
+    uint8_t  active;
+    uint16_t reserved;
+} UBX_TIME_SVIN_V0_GROUP0_t;
+
+#define UBX_TIM_SVIN_V0_SIZE    ((int)(sizeof(UBX_TIME_SVIN_V0_GROUP0_t) + UBX_FRAME_SIZE))
 
 /* ****************************************************************************************************************** */
 

--- a/ubloxcfg/ubloxcfg-50-ublox.jsonc
+++ b/ubloxcfg/ubloxcfg-50-ublox.jsonc
@@ -830,6 +830,12 @@
     { "id" : "0x20910605", "name" : "CFG-MSGOUT-UBX_RXM_SPARTN_I2C",        "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-RXM-SPARTN message on port I2C" },
     { "id" : "0x20910608", "name" : "CFG-MSGOUT-UBX_RXM_SPARTN_USB",        "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-RXM-SPARTN message on port USB" },
     // ......................................................................................................................................................................................................................
+    { "id" : "0x20910098", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_UART1",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port UART1" },
+    { "id" : "0x20910099", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_UART2",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port UART2" },
+    { "id" : "0x2091009b", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_SPI",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port SPI" },
+    { "id" : "0x20910097", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_I2C",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port I2C" },
+    { "id" : "0x2091009a", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_USB",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port USB" },
+    // ......................................................................................................................................................................................................................
     { "id" : "0x20910179", "name" : "CFG-MSGOUT-UBX_TIM_TM2_UART1",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port UART1" },
     { "id" : "0x2091017a", "name" : "CFG-MSGOUT-UBX_TIM_TM2_UART2",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port UART2" },
     { "id" : "0x2091017c", "name" : "CFG-MSGOUT-UBX_TIM_TM2_SPI",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port SPI" },

--- a/ubloxcfg/ubloxcfg.json
+++ b/ubloxcfg/ubloxcfg.json
@@ -642,6 +642,12 @@
     { "id" : "0x20910231", "name" : "CFG-MSGOUT-UBX_RXM_SFRBX_I2C",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-RXM-SFRBX message on port I2C" },
     { "id" : "0x20910234", "name" : "CFG-MSGOUT-UBX_RXM_SFRBX_USB",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-RXM-SFRBX message on port USB" },
     // ......................................................................................................................................................................................................................
+    { "id" : "0x20910098", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_UART1",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port UART1" },
+    { "id" : "0x20910099", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_UART2",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port UART2" },
+    { "id" : "0x2091009b", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_SPI",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port SPI" },
+    { "id" : "0x20910097", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_I2C",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port I2C" },
+    { "id" : "0x2091009a", "name" : "CFG-MSGOUT-UBX_TIM_SVIN_USB",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-SVIN message on port USB" },
+    // ......................................................................................................................................................................................................................
     { "id" : "0x20910179", "name" : "CFG-MSGOUT-UBX_TIM_TM2_UART1",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port UART1" },
     { "id" : "0x2091017a", "name" : "CFG-MSGOUT-UBX_TIM_TM2_UART2",         "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port UART2" },
     { "id" : "0x2091017c", "name" : "CFG-MSGOUT-UBX_TIM_TM2_SPI",           "size" : 1, "type" : "U1",                                         "title" : "Output rate of the UBX-TIM-TM2 message on port SPI" },

--- a/ubloxcfg/ubloxcfg_gen.c
+++ b/ubloxcfg/ubloxcfg_gen.c
@@ -18,6 +18,7 @@
 
 // Sources:
 // - u-blox ZED-F9P Interface Description (HPG 1.13) (https://www.u-blox.com/en/docs/UBX-18010854), copyright (c) 2020 u-blox AG
+// - u-blox ZED-F9T Interface Description (Version 29.00) (https://content.u-blox.com/sites/default/files/RCB-F9T_InterfaceDescription_%28UBX-19003606%29.pdf), copyright (c) 2020 u-blox AG
 // - u-blox NEO-M9N Interface description (SPG 4.04) (https://www.u-blox.com/en/docs/UBX-19035940), copyright (c) 2020 u-blox AG
 // - u-blox ZED-F9R Interface description (HPS 1.20) (https://www.u-blox.com/en/docs/UBX-19056845), copyright (c) 2020 u-blox AG
 // - u-blox F9 HPS 1.21 Interface Description (ZEF-F9R) (https://www.u-blox.com/en/docs/UBX-21019746), copyright (c) 2021 u-blox AG
@@ -4263,6 +4264,36 @@ static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxSecSigUsb =
     .order =  649, .title ="Output rate of the UBX-SEC-SIG message on port USB"
 };
 
+static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxTimSvinUart1 =
+{
+    .id = 0x20910098, .name = "CFG-MSGOUT-UBX_TIM_SVIN_UART1",                   .type = UBLOXCFG_TYPE_U1, .size = UBLOXCFG_SIZE_ONE,
+    .order =  650, .title ="Output rate of the UBX-TIM-SVIN message on port UART1"
+};
+
+static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxTimSvinUart2 =
+{
+    .id = 0x20910099, .name = "CFG-MSGOUT-UBX_TIM_SVIN_UART2",                   .type = UBLOXCFG_TYPE_U1, .size = UBLOXCFG_SIZE_ONE,
+    .order =  651, .title ="Output rate of the UBX-TIM-SVIN message on port UART2"
+};
+
+static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxTimSvinSpi =
+{
+    .id = 0x2091009b, .name = "CFG-MSGOUT-UBX_TIM_SVIN_SPI",                     .type = UBLOXCFG_TYPE_U1, .size = UBLOXCFG_SIZE_ONE,
+    .order =  652, .title ="Output rate of the UBX-TIM-SVIN message on port SPI"
+};
+
+static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxTimSvinI2c =
+{
+    .id = 0x20910097, .name = "CFG-MSGOUT-UBX_TIM_SVIN_I2C",                     .type = UBLOXCFG_TYPE_U1, .size = UBLOXCFG_SIZE_ONE,
+    .order =  653, .title ="Output rate of the UBX-TIM-SVIN message on port I2C"
+};
+
+static const UBLOXCFG_ITEM_t ubloxcfg_cfgMsgoutUbxTimSvinUsb =
+{
+    .id = 0x2091009a, .name = "CFG-MSGOUT-UBX_TIM_SVIN_USB",                     .type = UBLOXCFG_TYPE_U1, .size = UBLOXCFG_SIZE_ONE,
+    .order =  654, .title ="Output rate of the UBX-TIM-SVIN message on port USB"
+};
+
 static const UBLOXCFG_CONST_t ubloxcfg_cfgNavhpgDgnssmode_consts[2] =
 {
     {
@@ -7097,7 +7128,7 @@ static const UBLOXCFG_ITEM_t ubloxcfg_cfgUbloxcfgtestE4 =
     .nConsts =   5, .consts = ubloxcfg_cfgUbloxcfgtestE4_consts
 };
 
-static const UBLOXCFG_ITEM_t * const ubloxcfg_allItems[925] =
+static const UBLOXCFG_ITEM_t * const ubloxcfg_allItems[930] =
 {
     &ubloxcfg_cfgBdsUseGeoPrn,
     &ubloxcfg_cfgGeofenceConflvl,
@@ -7743,6 +7774,11 @@ static const UBLOXCFG_ITEM_t * const ubloxcfg_allItems[925] =
     &ubloxcfg_cfgMsgoutUbxTimVrfySpi,
     &ubloxcfg_cfgMsgoutUbxTimVrfyI2c,
     &ubloxcfg_cfgMsgoutUbxTimVrfyUsb,
+    &ubloxcfg_cfgMsgoutUbxTimSvinUart1,
+    &ubloxcfg_cfgMsgoutUbxTimSvinUart2,
+    &ubloxcfg_cfgMsgoutUbxTimSvinSpi,
+    &ubloxcfg_cfgMsgoutUbxTimSvinI2c,
+    &ubloxcfg_cfgMsgoutUbxTimSvinUsb,
     &ubloxcfg_cfgMsgoutUbxSecSigUart1,
     &ubloxcfg_cfgMsgoutUbxSecSigUart2,
     &ubloxcfg_cfgMsgoutUbxSecSigSpi,
@@ -9185,7 +9221,18 @@ static const UBLOXCFG_MSGRATE_t ubloxcfg_ubxTimVrfy =
     .itemI2c   = &ubloxcfg_cfgMsgoutUbxTimVrfyI2c,
     .itemUsb   = &ubloxcfg_cfgMsgoutUbxTimVrfyUsb
 };
-static const UBLOXCFG_MSGRATE_t * const ubloxcfg_allRates[116] =
+
+static const UBLOXCFG_MSGRATE_t ubloxcfg_ubxTimSvin =
+{
+    .msgName   = "UBX-TIM-SVIN",
+    .itemUart1 = &ubloxcfg_cfgMsgoutUbxTimSvinUart1,
+    .itemUart2 = &ubloxcfg_cfgMsgoutUbxTimSvinUart2,
+    .itemSpi   = &ubloxcfg_cfgMsgoutUbxTimSvinSpi,
+    .itemI2c   = &ubloxcfg_cfgMsgoutUbxTimSvinI2c,
+    .itemUsb   = &ubloxcfg_cfgMsgoutUbxTimSvinUsb
+};
+
+static const UBLOXCFG_MSGRATE_t * const ubloxcfg_allRates[117] =
 {
     &ubloxcfg_nmeaPubxPosition,
     &ubloxcfg_nmeaPubxSvstatus,
@@ -9302,7 +9349,8 @@ static const UBLOXCFG_MSGRATE_t * const ubloxcfg_allRates[116] =
     &ubloxcfg_ubxSecSig,
     &ubloxcfg_ubxTimTm2,
     &ubloxcfg_ubxTimTp,
-    &ubloxcfg_ubxTimVrfy
+    &ubloxcfg_ubxTimVrfy,
+    &ubloxcfg_ubxTimSvin
 };
 static const char * const ubloxcfg_allSources[5] =
 {

--- a/ubloxcfg/ubloxcfg_gen.h
+++ b/ubloxcfg/ubloxcfg_gen.h
@@ -5886,6 +5886,52 @@ typedef enum UBLOXCFG_CFG_ITFM_ANTSETTING_e
 ///@}
 
 /*!
+    \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1 CFG-MSGOUT-UBX_TIM_SVIN_UART1 (Output rate of the UBX-TIM-SVIN message on port UART1)
+    @{
+*/
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_ID           0x20910179                               //!< ID of CFG-MSGOUT-UBX_TIM_SVIN_UART1
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_STR          "CFG-MSGOUT-UBX_TIM_SVIN_UART1"           //!< Name of CFG-MSGOUT-UBX_TIM_SVIN_UART1
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_TYPE         U1                                       //!< Type of CFG-MSGOUT-UBX_TIM_SVIN_UART1
+///@}
+
+/*!
+    \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2 CFG-MSGOUT-UBX_TIM_SVIN_UART2 (Output rate of the UBX-TIM-SVIN message on port UART2)
+    @{
+*/
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_ID           0x2091017a                               //!< ID of CFG-MSGOUT-UBX_TIM_SVIN_UART2
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_STR          "CFG-MSGOUT-UBX_TIM_SVIN_UART2"           //!< Name of CFG-MSGOUT-UBX_TIM_SVIN_UART2
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_TYPE         U1                                       //!< Type of CFG-MSGOUT-UBX_TIM_SVIN_UART2
+///@}
+
+/*!
+    \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI CFG-MSGOUT-UBX_TIM_SVIN_SPI (Output rate of the UBX-TIM-SVIN message on port SPI)
+    @{
+*/
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_ID             0x2091017c                               //!< ID of CFG-MSGOUT-UBX_TIM_SVIN_SPI
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_STR            "CFG-MSGOUT-UBX_TIM_SVIN_SPI"             //!< Name of CFG-MSGOUT-UBX_TIM_SVIN_SPI
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_TYPE           U1                                       //!< Type of CFG-MSGOUT-UBX_TIM_SVIN_SPI
+///@}
+
+/*!
+    \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C CFG-MSGOUT-UBX_TIM_SVIN_I2C (Output rate of the UBX-TIM-SVIN message on port I2C)
+    @{
+*/
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_ID             0x20910178                               //!< ID of CFG-MSGOUT-UBX_TIM_SVIN_I2C
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_STR            "CFG-MSGOUT-UBX_TIM_SVIN_I2C"             //!< Name of CFG-MSGOUT-UBX_TIM_SVIN_I2C
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_TYPE           U1                                       //!< Type of CFG-MSGOUT-UBX_TIM_SVIN_I2C
+///@}
+
+/*!
+    \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB CFG-MSGOUT-UBX_TIM_SVIN_USB (Output rate of the UBX-TIM-SVIN message on port USB)
+    @{
+*/
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_ID             0x2091017b                               //!< ID of CFG-MSGOUT-UBX_TIM_SVIN_USB
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_STR            "CFG-MSGOUT-UBX_TIM_SVIN_USB"             //!< Name of CFG-MSGOUT-UBX_TIM_SVIN_USB
+#define UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_TYPE           U1                                       //!< Type of CFG-MSGOUT-UBX_TIM_SVIN_USB
+///@}
+
+
+/*!
     \defgroup UBLOXCFG_CFG_MSGOUT_UBX_TIM_TM2_UART1 CFG-MSGOUT-UBX_TIM_TM2_UART1 (Output rate of the UBX-TIM-TM2 message on port UART1)
     @{
 */
@@ -11704,6 +11750,28 @@ typedef enum UBLOXCFG_CFG_UBLOXCFGTEST_E4_e
 ///@}
 
 /*!
+    \defgroup UBLOXCFG_MSGOUT_UBX_TIM_SVIN UBX-TIM-SVIN
+    @{
+*/
+#define UBLOXCFG_UBX_TIM_SVIN_STR                           "UBX-TIM-SVIN"                                      //!< Message UBX-TIM-SVIN name
+#define UBLOXCFG_UBX_TIM_SVIN_UART1_ID                      UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_ID           //!< Config item ID for UBX-TIM-SVIN rate on port UART1
+#define UBLOXCFG_UBX_TIM_SVIN_UART1_STR                     UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_STR          //!< Config item name for UBX-TIM-SVIN rate on port UART1
+#define UBLOXCFG_UBX_TIM_SVIN_UART1_TYPE                    UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART1_TYPE         //!< Config item type for UBX-TIM-SVIN rate on port UART1
+#define UBLOXCFG_UBX_TIM_SVIN_UART2_ID                      UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_ID           //!< Config item ID for UBX-TIM-SVIN rate on port UART2
+#define UBLOXCFG_UBX_TIM_SVIN_UART2_STR                     UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_STR          //!< Config item name for UBX-TIM-SVIN rate on port UART2
+#define UBLOXCFG_UBX_TIM_SVIN_UART2_TYPE                    UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_UART2_TYPE         //!< Config item type for UBX-TIM-SVIN rate on port UART2
+#define UBLOXCFG_UBX_TIM_SVIN_SPI_ID                        UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_ID             //!< Config item ID for UBX-TIM-SVIN rate on port SPI
+#define UBLOXCFG_UBX_TIM_SVIN_SPI_STR                       UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_STR            //!< Config item name for UBX-TIM-SVIN rate on port SPI
+#define UBLOXCFG_UBX_TIM_SVIN_SPI_TYPE                      UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_SPI_TYPE           //!< Config item type for UBX-TIM-SVIN rate on port SPI
+#define UBLOXCFG_UBX_TIM_SVIN_I2C_ID                        UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_ID             //!< Config item ID for UBX-TIM-SVIN rate on port I2C
+#define UBLOXCFG_UBX_TIM_SVIN_I2C_STR                       UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_STR            //!< Config item name for UBX-TIM-SVIN rate on port I2C
+#define UBLOXCFG_UBX_TIM_SVIN_I2C_TYPE                      UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_I2C_TYPE           //!< Config item type for UBX-TIM-SVIN rate on port I2C
+#define UBLOXCFG_UBX_TIM_SVIN_USB_ID                        UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_ID             //!< Config item ID for UBX-TIM-SVIN rate on port USB
+#define UBLOXCFG_UBX_TIM_SVIN_USB_STR                       UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_STR            //!< Config item name for UBX-TIM-SVIN rate on port USB
+#define UBLOXCFG_UBX_TIM_SVIN_USB_TYPE                      UBLOXCFG_CFG_MSGOUT_UBX_TIM_SVIN_USB_TYPE           //!< Config item type for UBX-TIM-SVIN rate on port USB
+///@}
+
+/*!
     \defgroup UBLOXCFG_MSGOUT_UBX_TIM_TM2 UBX-TIM-TM2
     @{
 */
@@ -11771,9 +11839,9 @@ typedef enum UBLOXCFG_CFG_UBLOXCFGTEST_E4_e
 ///@}
 
 #ifndef _DOXYGEN_
-#define _UBLOXCFG_NUM_ITEMS 925
+#define _UBLOXCFG_NUM_ITEMS 930
 const void **_ubloxcfg_allItems(void);
-#define _UBLOXCFG_NUM_RATES 116
+#define _UBLOXCFG_NUM_RATES 117
 const void **_ubloxcfg_allRates(void);
 #define _UBLOXCFG_MAX_ITEM_LEN 35
 #define _UBLOXCFG_MAX_CONSTS_LEN 449


### PR DESCRIPTION
- Adds UBX-TIM-SVIN message which is used to monitor the Survey IN on Ublox receivers with timing options

Hi Flipflip,
I need to parse this message on my application and wanted to know if you think it would benefit ubloxcfg to have it

Best regards,
Charles